### PR TITLE
fix compile errors

### DIFF
--- a/gpio.c
+++ b/gpio.c
@@ -33,6 +33,7 @@
 #include <gpiod.h>
 #endif  // RPI
 
+bool gpio_active;
 char *power_script;
 static int gpio_state = -1;
 static bool initialized = false;

--- a/gpio.c
+++ b/gpio.c
@@ -33,6 +33,7 @@
 #include <gpiod.h>
 #endif  // RPI
 
+char *power_script;
 static int gpio_state = -1;
 static bool initialized = false;
 static int power_state = -1;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -791,7 +791,7 @@ struct codec *register_opus(void);
 void relay(int state);
 void relay_script(int state);
 bool gpio_active;
-char *power_script;
+extern char *power_script;
 
 #if RPI
 int gpio_chip;

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -790,7 +790,7 @@ struct codec *register_opus(void);
 #if GPIO
 void relay(int state);
 void relay_script(int state);
-bool gpio_active;
+extern bool gpio_active;
 extern char *power_script;
 
 #if RPI


### PR DESCRIPTION
When building cross-platform (for example, in a buildroot environment) with the -DGPIO option, compiler errors pop up because of declaration issues.